### PR TITLE
Add cross-platform startup scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,5 @@ venv.bak/
 .try
 .vscode/
 .vs/
+# Node modules
+node_modules/

--- a/borrowed_items_app/README.md
+++ b/borrowed_items_app/README.md
@@ -1,0 +1,11 @@
+# Borrowed Items App
+
+This directory contains a minimal full-stack web application.
+
+## Quick Start
+
+Run `start.sh` on Unix/macOS or `start.bat` on Windows to launch both the
+server and client. The script installs dependencies if needed and opens the
+application in your default browser.
+
+Node.js must be installed before using these scripts.

--- a/borrowed_items_app/client/.babelrc
+++ b/borrowed_items_app/client/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-react"]
+}

--- a/borrowed_items_app/client/README.md
+++ b/borrowed_items_app/client/README.md
@@ -1,0 +1,15 @@
+# Borrowed Items Client
+
+A simple React front-end for the item check-in app.
+
+## Usage
+
+Install dependencies and start the development server:
+
+```bash
+npm install
+npm start
+```
+
+The app proxies API requests to `localhost:3001` where the server is expected to run.
+You can also run `../start.sh` (or `../start.bat` on Windows) from the `borrowed_items_app` directory to launch the full stack.

--- a/borrowed_items_app/client/package.json
+++ b/borrowed_items_app/client/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "borrowed-items-client",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.22.20",
+    "@babel/preset-react": "^7.22.5",
+    "babel-loader": "^9.1.2",
+    "html-webpack-plugin": "^5.5.3",
+    "webpack": "^5.88.1",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.1"
+  },
+  "scripts": {
+    "start": "webpack serve --mode development --open",
+    "build": "webpack --mode production"
+  }
+}

--- a/borrowed_items_app/client/public/index.html
+++ b/borrowed_items_app/client/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Borrowed Items App</title>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/borrowed_items_app/client/src/App.js
+++ b/borrowed_items_app/client/src/App.js
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from 'react';
+
+function App() {
+  const [user, setUser] = useState(null);
+  const [items, setItems] = useState([]);
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+
+  const login = async () => {
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setUser(data);
+    }
+  };
+
+  useEffect(() => {
+    if (user) {
+      fetch(`/api/items/${user.id}`)
+        .then((res) => res.json())
+        .then(setItems);
+    }
+  }, [user]);
+
+  const returnItem = async (itemId) => {
+    await fetch(`/api/items/${itemId}/return`, { method: 'POST' });
+    setItems(items.map((i) => (i.id === itemId ? { ...i, returned: 1 } : i)));
+  };
+
+  if (!user) {
+    return (
+      <div>
+        <h2>Login</h2>
+        <input placeholder="Username" value={username} onChange={(e) => setUsername(e.target.value)} />
+        <input placeholder="Password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+        <button onClick={login}>Login</button>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h2>Borrowed Items</h2>
+      <ul>
+        {items.map((item) => (
+          <li key={item.id}>
+            {item.name} - {item.returned ? 'Returned' : 'Borrowed'}
+            {!item.returned && <button onClick={() => returnItem(item.id)}>Return</button>}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default App;

--- a/borrowed_items_app/client/src/index.js
+++ b/borrowed_items_app/client/src/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(<App />);

--- a/borrowed_items_app/client/webpack.config.js
+++ b/borrowed_items_app/client/webpack.config.js
@@ -1,0 +1,35 @@
+const path = require('path');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = {
+  entry: './src/index.js',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'bundle.js'
+  },
+  module: {
+    rules: [
+      {
+        test: /\.jsx?$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['@babel/preset-react']
+          }
+        }
+      }
+    ]
+  },
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: './public/index.html'
+    })
+  ],
+  devServer: {
+    port: 3000,
+    proxy: {
+      '/api': 'http://localhost:3001'
+    }
+  }
+};

--- a/borrowed_items_app/server/README.md
+++ b/borrowed_items_app/server/README.md
@@ -1,0 +1,19 @@
+# Borrowed Items Server
+
+This Express.js server provides a simple API for managing borrowed items.
+It uses SQLite to store user and item information.
+
+## Endpoints
+
+- `POST /api/login` – Authenticate a user.
+- `GET /api/items/:userId` – Retrieve items borrowed by a specific user.
+- `POST /api/items/:itemId/return` – Mark an item as returned.
+- `GET /api/admin/report` – Retrieve a list of all items for administrative purposes.
+
+Run the server with:
+
+```bash
+npm install
+npm start
+```
+You can also run `../start.sh` (or `../start.bat` on Windows) from this directory to start both the server and client together.

--- a/borrowed_items_app/server/index.js
+++ b/borrowed_items_app/server/index.js
@@ -1,0 +1,68 @@
+const express = require('express');
+const bodyParser = require('body-parser');
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 3001;
+
+// Database setup
+const db = new sqlite3.Database(path.join(__dirname, 'database.db'));
+
+db.serialize(() => {
+  db.run(`CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT UNIQUE,
+    password TEXT
+  )`);
+  db.run(`CREATE TABLE IF NOT EXISTS items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT,
+    borrowed_by INTEGER,
+    returned INTEGER DEFAULT 0,
+    FOREIGN KEY(borrowed_by) REFERENCES users(id)
+  )`);
+});
+
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({ extended: true }));
+
+// Simple login endpoint
+app.post('/api/login', (req, res) => {
+  const { username, password } = req.body;
+  db.get('SELECT * FROM users WHERE username = ? AND password = ?', [username, password], (err, row) => {
+    if (err) return res.status(500).json({ error: err.message });
+    if (!row) return res.status(401).json({ error: 'Invalid credentials' });
+    res.json({ id: row.id, username: row.username });
+  });
+});
+
+// Fetch items for a user
+app.get('/api/items/:userId', (req, res) => {
+  const { userId } = req.params;
+  db.all('SELECT * FROM items WHERE borrowed_by = ?', [userId], (err, rows) => {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json(rows);
+  });
+});
+
+// Mark item as returned
+app.post('/api/items/:itemId/return', (req, res) => {
+  const { itemId } = req.params;
+  db.run('UPDATE items SET returned = 1 WHERE id = ?', [itemId], function (err) {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json({ success: true });
+  });
+});
+
+// Admin report
+app.get('/api/admin/report', (req, res) => {
+  db.all('SELECT * FROM items', (err, rows) => {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json(rows);
+  });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/borrowed_items_app/server/package.json
+++ b/borrowed_items_app/server/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "borrowed-items-server",
+  "version": "1.0.0",
+  "description": "Backend for item check-in app",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "body-parser": "^1.20.2",
+    "express": "^4.18.2",
+    "sqlite3": "^5.1.2"
+  }
+}

--- a/borrowed_items_app/start.bat
+++ b/borrowed_items_app/start.bat
@@ -1,0 +1,46 @@
+@echo off
+REM start.bat - Launch the Borrowed Items app on Windows
+
+set BASE_DIR=%~dp0
+set SERVER_DIR=%BASE_DIR%server
+set CLIENT_DIR=%BASE_DIR%client
+
+REM Check that Node.js is installed
+where node >nul 2>nul
+if %ERRORLEVEL% NEQ 0 (
+  echo Node.js is required. Please install it from https://nodejs.org/
+  pause
+  exit /b 1
+)
+
+REM Create a default .env if needed
+if not exist "%SERVER_DIR%\.env" (
+  echo PORT=3001 > "%SERVER_DIR%\.env"
+  echo Created default %%SERVER_DIR%%\.env
+)
+
+REM Install server dependencies if missing
+if not exist "%SERVER_DIR%\node_modules" (
+  echo Installing server dependencies...
+  pushd "%SERVER_DIR%"
+  npm install
+  popd
+)
+
+REM Start the server in a new window
+start "Server" cmd /k "cd /d %SERVER_DIR% && npm start"
+
+REM Install client dependencies if missing
+if not exist "%CLIENT_DIR%\node_modules" (
+  echo Installing client dependencies...
+  pushd "%CLIENT_DIR%"
+  npm install
+  popd
+)
+
+REM Start the client in a new window
+start "Client" cmd /k "cd /d %CLIENT_DIR% && npm start"
+
+REM Give servers time to start then open browser
+ping -n 4 127.0.0.1 >nul
+start http://localhost:3000

--- a/borrowed_items_app/start.sh
+++ b/borrowed_items_app/start.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# start.sh - Launch the Borrowed Items app (server and client)
+# This script installs dependencies, starts the backend and frontend,
+# and opens the app in the default browser.
+
+set -e
+
+# Determine directories
+BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
+SERVER_DIR="$BASE_DIR/server"
+CLIENT_DIR="$BASE_DIR/client"
+
+# Ensure Node.js is installed
+if ! command -v node >/dev/null 2>&1; then
+  echo "Node.js is required. Please install it from https://nodejs.org/" >&2
+  exit 1
+fi
+
+# Optional .env file
+ENV_FILE="$SERVER_DIR/.env"
+if [ ! -f "$ENV_FILE" ]; then
+  echo "PORT=3001" > "$ENV_FILE"
+  echo "Created default $ENV_FILE"
+fi
+
+# Install server dependencies if missing
+if [ ! -d "$SERVER_DIR/node_modules" ]; then
+  echo "Installing server dependencies..."
+  (cd "$SERVER_DIR" && npm install)
+fi
+
+# Start server in the background
+(cd "$SERVER_DIR" && npm start &) 
+SERVER_PID=$!
+
+# Install client dependencies if missing
+if [ ! -d "$CLIENT_DIR/node_modules" ]; then
+  echo "Installing client dependencies..."
+  (cd "$CLIENT_DIR" && npm install)
+fi
+
+# Start client in the background
+(cd "$CLIENT_DIR" && npm start &) 
+CLIENT_PID=$!
+
+# Wait briefly to let dev servers start
+sleep 3
+
+# Open the app in the default browser
+URL="http://localhost:3000"
+if command -v xdg-open >/dev/null 2>&1; then
+  xdg-open "$URL" >/dev/null 2>&1 &
+elif command -v open >/dev/null 2>&1; then
+  open "$URL" >/dev/null 2>&1 &
+else
+  echo "Please open $URL in your browser"
+fi
+
+# Wait for background processes
+wait $SERVER_PID $CLIENT_PID


### PR DESCRIPTION
## Summary
- create `start.sh` and `start.bat` to run both backend and frontend together
- add a root README for the borrowed items app explaining quick start
- reference the new scripts in server and client READMEs

## Testing
- `pre-commit` *(fails: command not found)*