### PR TITLE
Implement simplified self-attestation form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ venv.bak/
 .try
 .vscode/
 .vs/
+# Node modules
+node_modules/
+borrowed_items_app/server/database.db

--- a/borrowed_items_app/client/.babelrc
+++ b/borrowed_items_app/client/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-react"]
+}

--- a/borrowed_items_app/client/README.md
+++ b/borrowed_items_app/client/README.md
@@ -1,0 +1,14 @@
+# Borrowed Items Client
+
+A simple React front-end that lets students confirm they returned equipment.
+
+## Usage
+
+Install dependencies and start the development server:
+
+```bash
+npm install
+npm start
+```
+
+The app proxies API requests to `localhost:3001` where the server is expected to run.

--- a/borrowed_items_app/client/package.json
+++ b/borrowed_items_app/client/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "borrowed-items-client",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.22.20",
+    "@babel/preset-react": "^7.22.5",
+    "babel-loader": "^9.1.2",
+    "html-webpack-plugin": "^5.5.3",
+    "webpack": "^5.88.1",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.1"
+  },
+  "scripts": {
+    "start": "webpack serve --mode development --open",
+    "build": "webpack --mode production"
+  }
+}

--- a/borrowed_items_app/client/public/index.html
+++ b/borrowed_items_app/client/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Borrowed Items App</title>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/borrowed_items_app/client/src/App.js
+++ b/borrowed_items_app/client/src/App.js
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+
+function App() {
+  const [name, setName] = useState('');
+  const [laptop, setLaptop] = useState(false);
+  const [charger, setCharger] = useState(false);
+  const [yonderpouch, setYonderpouch] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  const handleSubmit = async () => {
+    await fetch('/api/return', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, laptop, charger, yonderpouch }),
+    });
+    setSubmitted(true);
+  };
+
+  if (submitted) {
+    return (
+      <div>
+        <h2>Thank you!</h2>
+        <p>Your submission has been recorded.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h2>Equipment Return Form</h2>
+      <div>
+        <label>
+          Your Name:
+          <input value={name} onChange={(e) => setName(e.target.value)} />
+        </label>
+      </div>
+      <div>
+        <label>
+          <input
+            type="checkbox"
+            checked={laptop}
+            onChange={() => setLaptop(!laptop)}
+          />
+          Laptop returned
+        </label>
+      </div>
+      <div>
+        <label>
+          <input
+            type="checkbox"
+            checked={charger}
+            onChange={() => setCharger(!charger)}
+          />
+          Charger returned
+        </label>
+      </div>
+      <div>
+        <label>
+          <input
+            type="checkbox"
+            checked={yonderpouch}
+            onChange={() => setYonderpouch(!yonderpouch)}
+          />
+          Yonder pouch returned
+        </label>
+      </div>
+      <button onClick={handleSubmit}>Submit</button>
+    </div>
+  );
+}
+
+export default App;

--- a/borrowed_items_app/client/src/index.js
+++ b/borrowed_items_app/client/src/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(<App />);

--- a/borrowed_items_app/client/webpack.config.js
+++ b/borrowed_items_app/client/webpack.config.js
@@ -1,0 +1,35 @@
+const path = require('path');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = {
+  entry: './src/index.js',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'bundle.js'
+  },
+  module: {
+    rules: [
+      {
+        test: /\.jsx?$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['@babel/preset-react']
+          }
+        }
+      }
+    ]
+  },
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: './public/index.html'
+    })
+  ],
+  devServer: {
+    port: 3000,
+    proxy: {
+      '/api': 'http://localhost:3001'
+    }
+  }
+};

--- a/borrowed_items_app/server/README.md
+++ b/borrowed_items_app/server/README.md
@@ -1,0 +1,16 @@
+# Borrowed Items Server
+
+This Express.js server records student self-attestations for returning equipment.
+It uses SQLite to store each submission.
+
+## Endpoints
+
+- `POST /api/return` – Record that a student returned items.
+- `GET /api/admin/report` – Retrieve all return submissions for administrative purposes.
+
+Run the server with:
+
+```bash
+npm install
+npm start
+```

--- a/borrowed_items_app/server/index.js
+++ b/borrowed_items_app/server/index.js
@@ -1,0 +1,48 @@
+const express = require('express');
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 3001;
+
+// Database setup
+const db = new sqlite3.Database(path.join(__dirname, 'database.db'));
+
+db.serialize(() => {
+  db.run(`CREATE TABLE IF NOT EXISTS returns (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT,
+    laptop INTEGER,
+    charger INTEGER,
+    yonderpouch INTEGER,
+    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+  )`);
+});
+
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+
+// Record a return submission
+app.post('/api/return', (req, res) => {
+  const { name, laptop, charger, yonderpouch } = req.body;
+  db.run(
+    'INSERT INTO returns (name, laptop, charger, yonderpouch) VALUES (?, ?, ?, ?)',
+    [name, laptop ? 1 : 0, charger ? 1 : 0, yonderpouch ? 1 : 0],
+    function (err) {
+      if (err) return res.status(500).json({ error: err.message });
+      res.json({ success: true, id: this.lastID });
+    }
+  );
+});
+
+// Admin report
+app.get('/api/admin/report', (req, res) => {
+  db.all('SELECT * FROM returns ORDER BY timestamp DESC', (err, rows) => {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json(rows);
+  });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/borrowed_items_app/server/package.json
+++ b/borrowed_items_app/server/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "borrowed-items-server",
+  "version": "1.0.0",
+  "description": "Backend for item check-in app",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "sqlite3": "^5.1.2"
+  }
+}


### PR DESCRIPTION
## Summary
- adjust server to record item return submissions without login
- rewrite React client as a simple equipment return form
- remove unused body-parser dependency
- ignore generated SQLite database
- update READMEs with new behavior

## Testing
- ❌ `pre-commit` *(failed: command not found)*