### PR TITLE
Implement single start script and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ venv.bak/
 .try
 .vscode/
 .vs/
+# Node modules
+node_modules/
+borrowed_items_app/server/database.db

--- a/borrowed_items_app/README.md
+++ b/borrowed_items_app/README.md
@@ -1,0 +1,13 @@
+# Borrowed Items App
+
+This folder contains a small demo application with a Node/Express backend and a React frontend.
+
+## Quick start
+
+Run the `start.js` script to install dependencies (if needed) and launch both services:
+
+```bash
+node start.js
+```
+
+The frontend will open in your default browser at [http://localhost:3000](http://localhost:3000).

--- a/borrowed_items_app/client/.babelrc
+++ b/borrowed_items_app/client/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-react"]
+}

--- a/borrowed_items_app/client/README.md
+++ b/borrowed_items_app/client/README.md
@@ -1,0 +1,23 @@
+# Borrowed Items Client
+
+A simple React front-end for the item check-in app.
+
+## Usage
+
+> **Prerequisite**: [Node.js](https://nodejs.org/) must be installed to provide
+> the `npm` command used below.
+
+Install dependencies and start the development server:
+
+```bash
+npm install
+npm start
+```
+
+You can also start both the client and server together from the parent directory:
+
+```bash
+node start.js
+```
+
+The app proxies API requests to `localhost:3001` where the server is expected to run.

--- a/borrowed_items_app/client/package.json
+++ b/borrowed_items_app/client/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "borrowed-items-client",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.22.20",
+    "@babel/preset-react": "^7.22.5",
+    "babel-loader": "^9.1.2",
+    "html-webpack-plugin": "^5.5.3",
+    "webpack": "^5.88.1",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.1"
+  },
+  "scripts": {
+    "start": "webpack serve --mode development --open",
+    "build": "webpack --mode production"
+  }
+}

--- a/borrowed_items_app/client/public/index.html
+++ b/borrowed_items_app/client/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Borrowed Items App</title>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/borrowed_items_app/client/src/App.js
+++ b/borrowed_items_app/client/src/App.js
@@ -1,0 +1,66 @@
+import React, { useEffect, useState } from 'react';
+
+function App() {
+  const [user, setUser] = useState(null);
+  const [items, setItems] = useState([]);
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [loginError, setLoginError] = useState('');
+
+  const login = async () => {
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setUser(data);
+      setLoginError('');
+    } else {
+      const err = await res.json();
+      setLoginError(err.error || 'Login failed');
+    }
+  };
+
+  useEffect(() => {
+    if (user) {
+      fetch(`/api/items/${user.id}`)
+        .then((res) => res.json())
+        .then(setItems);
+    }
+  }, [user]);
+
+  const returnItem = async (itemId) => {
+    await fetch(`/api/items/${itemId}/return`, { method: 'POST' });
+    setItems(items.map((i) => (i.id === itemId ? { ...i, returned: 1 } : i)));
+  };
+
+  if (!user) {
+    return (
+      <div>
+        <h2>Login</h2>
+        <input placeholder="Username" value={username} onChange={(e) => setUsername(e.target.value)} />
+        <input placeholder="Password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+        <button onClick={login}>Login</button>
+        {loginError && <p style={{ color: 'red' }}>{loginError}</p>}
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h2>Borrowed Items</h2>
+      <ul>
+        {items.map((item) => (
+          <li key={item.id}>
+            {item.name} - {item.returned ? 'Returned' : 'Borrowed'}
+            {!item.returned && <button onClick={() => returnItem(item.id)}>Return</button>}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default App;

--- a/borrowed_items_app/client/src/index.js
+++ b/borrowed_items_app/client/src/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(<App />);

--- a/borrowed_items_app/client/webpack.config.js
+++ b/borrowed_items_app/client/webpack.config.js
@@ -1,0 +1,35 @@
+const path = require('path');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = {
+  entry: './src/index.js',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'bundle.js'
+  },
+  module: {
+    rules: [
+      {
+        test: /\.jsx?$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['@babel/preset-react']
+          }
+        }
+      }
+    ]
+  },
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: './public/index.html'
+    })
+  ],
+  devServer: {
+    port: 3000,
+    proxy: {
+      '/api': 'http://localhost:3001'
+    }
+  }
+};

--- a/borrowed_items_app/server/README.md
+++ b/borrowed_items_app/server/README.md
@@ -1,0 +1,30 @@
+# Borrowed Items Server
+
+This Express.js server provides a simple API for managing borrowed items.
+It uses SQLite to store user and item information.
+
+> **Prerequisite**: [Node.js](https://nodejs.org/) must be installed on your
+> machine (which also provides `npm`).
+
+## Endpoints
+
+- `POST /api/login` – Authenticate a user.
+- `GET /api/items/:userId` – Retrieve items borrowed by a specific user.
+- `POST /api/items/:itemId/return` – Mark an item as returned.
+- `GET /api/admin/report` – Retrieve a list of all items for administrative purposes.
+
+Run the server with:
+
+```bash
+npm install
+npm start
+```
+
+To populate the database with example data run:
+
+```bash
+node seed.js
+```
+
+Alternatively, from the `borrowed_items_app` directory you can run `node start.js`
+to launch both the server and client at once.

--- a/borrowed_items_app/server/index.js
+++ b/borrowed_items_app/server/index.js
@@ -1,0 +1,67 @@
+const express = require('express');
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 3001;
+
+// Database setup
+const db = new sqlite3.Database(path.join(__dirname, 'database.db'));
+
+db.serialize(() => {
+  db.run(`CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT UNIQUE,
+    password TEXT
+  )`);
+  db.run(`CREATE TABLE IF NOT EXISTS items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT,
+    borrowed_by INTEGER,
+    returned INTEGER DEFAULT 0,
+    FOREIGN KEY(borrowed_by) REFERENCES users(id)
+  )`);
+});
+
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+
+// Simple login endpoint
+app.post('/api/login', (req, res) => {
+  const { username, password } = req.body;
+  db.get('SELECT * FROM users WHERE username = ? AND password = ?', [username, password], (err, row) => {
+    if (err) return res.status(500).json({ error: err.message });
+    if (!row) return res.status(401).json({ error: 'Invalid credentials' });
+    res.json({ id: row.id, username: row.username });
+  });
+});
+
+// Fetch items for a user
+app.get('/api/items/:userId', (req, res) => {
+  const { userId } = req.params;
+  db.all('SELECT * FROM items WHERE borrowed_by = ?', [userId], (err, rows) => {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json(rows);
+  });
+});
+
+// Mark item as returned
+app.post('/api/items/:itemId/return', (req, res) => {
+  const { itemId } = req.params;
+  db.run('UPDATE items SET returned = 1 WHERE id = ?', [itemId], function (err) {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json({ success: true });
+  });
+});
+
+// Admin report
+app.get('/api/admin/report', (req, res) => {
+  db.all('SELECT * FROM items', (err, rows) => {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json(rows);
+  });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/borrowed_items_app/server/package.json
+++ b/borrowed_items_app/server/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "borrowed-items-server",
+  "version": "1.0.0",
+  "description": "Backend for item check-in app",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "sqlite3": "^5.1.2"
+  }
+}

--- a/borrowed_items_app/server/seed.js
+++ b/borrowed_items_app/server/seed.js
@@ -1,0 +1,18 @@
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+
+const db = new sqlite3.Database(path.join(__dirname, 'database.db'));
+
+db.serialize(() => {
+  db.run('DELETE FROM users');
+  db.run('DELETE FROM items');
+
+  db.run('INSERT INTO users (username, password) VALUES ("alice", "password"), ("bob", "password")');
+
+  db.run('INSERT INTO items (name, borrowed_by, returned) VALUES ' +
+    '("Laptop", 1, 0),' +
+    '("Charger", 1, 0),' +
+    '("Yonder Pouch", 2, 0)');
+});
+
+db.close();

--- a/borrowed_items_app/start.js
+++ b/borrowed_items_app/start.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+const { spawn, execSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+const root = __dirname;
+const serverDir = path.join(root, 'server');
+const clientDir = path.join(root, 'client');
+
+function ensureDeps(dir) {
+  if (!fs.existsSync(path.join(dir, 'node_modules'))) {
+    console.log(`Installing dependencies in ${dir}`);
+    execSync('npm install', { cwd: dir, stdio: 'inherit' });
+  }
+}
+
+function ensureEnv(dir) {
+  const env = path.join(dir, '.env');
+  if (!fs.existsSync(env)) {
+    console.log(`Creating empty .env in ${dir}`);
+    fs.writeFileSync(env, '');
+  }
+}
+
+ensureDeps(serverDir);
+ensureDeps(clientDir);
+ensureEnv(serverDir);
+ensureEnv(clientDir);
+
+console.log('Starting server and client...');
+const server = spawn('npm', ['start'], { cwd: serverDir, stdio: 'inherit', shell: true });
+const client = spawn('npm', ['start'], { cwd: clientDir, stdio: 'inherit', shell: true });
+
+const url = 'http://localhost:3000';
+function openBrowser() {
+  const command = process.platform === 'darwin'
+    ? 'open'
+    : process.platform === 'win32'
+      ? 'start'
+      : 'xdg-open';
+  spawn(command, [url], { shell: true, stdio: 'ignore' });
+}
+
+setTimeout(openBrowser, 5000);
+
+process.on('SIGINT', () => {
+  server.kill('SIGINT');
+  client.kill('SIGINT');
+  process.exit();
+});


### PR DESCRIPTION
## Summary
- add a simple start.js to run server and client together
- ignore SQLite database
- display login errors in the React client
- remove body-parser and use Express' JSON parsing
- seed the database with sample data and document prerequisites

## Testing
- `pre-commit` *(fails: command not found)*