### PR TITLE
Add startup scripts and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ venv.bak/
 .try
 .vscode/
 .vs/
+# Node modules
+node_modules/
+borrowed_items_app/server/database.db

--- a/borrowed_items_app/client/.babelrc
+++ b/borrowed_items_app/client/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-react"]
+}

--- a/borrowed_items_app/client/README.md
+++ b/borrowed_items_app/client/README.md
@@ -1,0 +1,22 @@
+# Borrowed Items Client
+
+A simple React front-end for the item check-in app.
+
+## Prerequisites
+
+Install [Node.js](https://nodejs.org/) so that the `npm` command is available.
+
+## Usage
+
+Install dependencies and start the development server:
+
+```bash
+npm install
+npm start
+```
+
+The app proxies API requests to `localhost:3001` where the server is expected to run.
+
+Alternatively, from the parent `borrowed_items_app` directory you can execute
+the `start.sh` (Unix) or `start.bat` (Windows) script to launch both the server
+and client together.

--- a/borrowed_items_app/client/package.json
+++ b/borrowed_items_app/client/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "borrowed-items-client",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.22.20",
+    "@babel/preset-react": "^7.22.5",
+    "babel-loader": "^9.1.2",
+    "html-webpack-plugin": "^5.5.3",
+    "webpack": "^5.88.1",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.1"
+  },
+  "scripts": {
+    "start": "webpack serve --mode development --open",
+    "build": "webpack --mode production"
+  }
+}

--- a/borrowed_items_app/client/public/index.html
+++ b/borrowed_items_app/client/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Borrowed Items App</title>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/borrowed_items_app/client/src/App.js
+++ b/borrowed_items_app/client/src/App.js
@@ -1,0 +1,66 @@
+import React, { useEffect, useState } from 'react';
+
+function App() {
+  const [user, setUser] = useState(null);
+  const [items, setItems] = useState([]);
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [loginError, setLoginError] = useState('');
+
+  const login = async () => {
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setUser(data);
+      setLoginError('');
+    } else {
+      const err = await res.json().catch(() => ({ error: 'Login failed' }));
+      setLoginError(err.error || 'Login failed');
+    }
+  };
+
+  useEffect(() => {
+    if (user) {
+      fetch(`/api/items/${user.id}`)
+        .then((res) => res.json())
+        .then(setItems);
+    }
+  }, [user]);
+
+  const returnItem = async (itemId) => {
+    await fetch(`/api/items/${itemId}/return`, { method: 'POST' });
+    setItems(items.map((i) => (i.id === itemId ? { ...i, returned: 1 } : i)));
+  };
+
+  if (!user) {
+    return (
+      <div>
+        <h2>Login</h2>
+        <input placeholder="Username" value={username} onChange={(e) => setUsername(e.target.value)} />
+        <input placeholder="Password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+        {loginError && <p style={{ color: 'red' }}>{loginError}</p>}
+        <button onClick={login}>Login</button>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h2>Borrowed Items</h2>
+      <ul>
+        {items.map((item) => (
+          <li key={item.id}>
+            {item.name} - {item.returned ? 'Returned' : 'Borrowed'}
+            {!item.returned && <button onClick={() => returnItem(item.id)}>Return</button>}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default App;

--- a/borrowed_items_app/client/src/index.js
+++ b/borrowed_items_app/client/src/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(<App />);

--- a/borrowed_items_app/client/webpack.config.js
+++ b/borrowed_items_app/client/webpack.config.js
@@ -1,0 +1,35 @@
+const path = require('path');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = {
+  entry: './src/index.js',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'bundle.js'
+  },
+  module: {
+    rules: [
+      {
+        test: /\.jsx?$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['@babel/preset-react']
+          }
+        }
+      }
+    ]
+  },
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: './public/index.html'
+    })
+  ],
+  devServer: {
+    port: 3000,
+    proxy: {
+      '/api': 'http://localhost:3001'
+    }
+  }
+};

--- a/borrowed_items_app/server/README.md
+++ b/borrowed_items_app/server/README.md
@@ -1,0 +1,32 @@
+# Borrowed Items Server
+
+This Express.js server provides a simple API for managing borrowed items.
+It uses SQLite to store user and item information.
+
+## Prerequisites
+
+Make sure [Node.js](https://nodejs.org/) (which includes `npm`) is installed on
+your system before continuing.
+
+## Endpoints
+
+- `POST /api/login` – Authenticate a user.
+- `GET /api/items/:userId` – Retrieve items borrowed by a specific user.
+- `POST /api/items/:itemId/return` – Mark an item as returned.
+- `GET /api/admin/report` – Retrieve a list of all items for administrative purposes.
+
+Run the server with:
+
+```bash
+npm install
+npm start
+```
+
+Alternatively, run the `start.sh` (Unix) or `start.bat` (Windows) script from
+the parent `borrowed_items_app` directory to launch the entire application.
+
+To populate the database with sample data, run:
+
+```bash
+node seed.js
+```

--- a/borrowed_items_app/server/index.js
+++ b/borrowed_items_app/server/index.js
@@ -1,0 +1,67 @@
+const express = require('express');
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 3001;
+
+// Database setup
+const db = new sqlite3.Database(path.join(__dirname, 'database.db'));
+
+db.serialize(() => {
+  db.run(`CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT UNIQUE,
+    password TEXT
+  )`);
+  db.run(`CREATE TABLE IF NOT EXISTS items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT,
+    borrowed_by INTEGER,
+    returned INTEGER DEFAULT 0,
+    FOREIGN KEY(borrowed_by) REFERENCES users(id)
+  )`);
+});
+
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+
+// Simple login endpoint
+app.post('/api/login', (req, res) => {
+  const { username, password } = req.body;
+  db.get('SELECT * FROM users WHERE username = ? AND password = ?', [username, password], (err, row) => {
+    if (err) return res.status(500).json({ error: err.message });
+    if (!row) return res.status(401).json({ error: 'Invalid credentials' });
+    res.json({ id: row.id, username: row.username });
+  });
+});
+
+// Fetch items for a user
+app.get('/api/items/:userId', (req, res) => {
+  const { userId } = req.params;
+  db.all('SELECT * FROM items WHERE borrowed_by = ?', [userId], (err, rows) => {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json(rows);
+  });
+});
+
+// Mark item as returned
+app.post('/api/items/:itemId/return', (req, res) => {
+  const { itemId } = req.params;
+  db.run('UPDATE items SET returned = 1 WHERE id = ?', [itemId], function (err) {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json({ success: true });
+  });
+});
+
+// Admin report
+app.get('/api/admin/report', (req, res) => {
+  db.all('SELECT * FROM items', (err, rows) => {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json(rows);
+  });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/borrowed_items_app/server/package.json
+++ b/borrowed_items_app/server/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "borrowed-items-server",
+  "version": "1.0.0",
+  "description": "Backend for item check-in app",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "sqlite3": "^5.1.2"
+  }
+}

--- a/borrowed_items_app/server/seed.js
+++ b/borrowed_items_app/server/seed.js
@@ -1,0 +1,26 @@
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+
+const db = new sqlite3.Database(path.join(__dirname, 'database.db'));
+
+db.serialize(() => {
+  db.run(`CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT UNIQUE,
+    password TEXT
+  )`);
+  db.run(`CREATE TABLE IF NOT EXISTS items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT,
+    borrowed_by INTEGER,
+    returned INTEGER DEFAULT 0,
+    FOREIGN KEY(borrowed_by) REFERENCES users(id)
+  )`);
+
+  db.run("INSERT OR IGNORE INTO users (id, username, password) VALUES (1, 'student', 'password')");
+  db.run("INSERT OR IGNORE INTO items (name, borrowed_by, returned) VALUES ('Laptop', 1, 0)");
+  db.run("INSERT OR IGNORE INTO items (name, borrowed_by, returned) VALUES ('Charger', 1, 0)");
+  db.run("INSERT OR IGNORE INTO items (name, borrowed_by, returned) VALUES ('Yonder Pouch', 1, 0)");
+});
+
+db.close(() => console.log('Database seeded.'));

--- a/borrowed_items_app/start.bat
+++ b/borrowed_items_app/start.bat
@@ -1,0 +1,28 @@
+@echo off
+REM Start the Borrowed Items App (Windows)
+REM Installs dependencies if needed, starts server and client, and opens browser.
+
+if not exist server\node_modules (
+  echo Installing server dependencies...
+  pushd server
+  npm install
+  popd
+)
+
+if not exist client\node_modules (
+  echo Installing client dependencies...
+  pushd client
+  npm install
+  popd
+)
+
+if not exist .env (
+  echo PORT=3001> .env
+  echo Created default .env
+)
+
+start cmd /k "cd server && npm start"
+rem Wait a little for the server to start
+ping 127.0.0.1 -n 4 > nul
+start cmd /k "cd client && npm start"
+start http://localhost:3000

--- a/borrowed_items_app/start.sh
+++ b/borrowed_items_app/start.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Start the Borrowed Items App (Unix/macOS)
+# This script installs dependencies if needed, starts the server and client,
+# and opens the web app in the default browser.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# Check for Node
+if ! command -v npm >/dev/null 2>&1; then
+  echo "npm not found. Please install Node.js from https://nodejs.org/"
+  exit 1
+fi
+
+# Create a .env file if missing
+if [ ! -f .env ]; then
+  echo "PORT=3001" > .env
+  echo "Created default .env in $(pwd)"
+fi
+
+# Install backend dependencies
+if [ ! -d server/node_modules ]; then
+  echo "Installing server dependencies..."
+  (cd server && npm install)
+fi
+
+# Install frontend dependencies
+if [ ! -d client/node_modules ]; then
+  echo "Installing client dependencies..."
+  (cd client && npm install)
+fi
+
+# Start backend
+(cd server && npm start) &
+SERVER_PID=$!
+
+# Give server a moment to start
+sleep 3
+
+# Start frontend
+(cd client && npm start) &
+CLIENT_PID=$!
+
+# Open application in default browser
+URL="http://localhost:3000"
+if command -v xdg-open >/dev/null 2>&1; then
+  xdg-open "$URL" >/dev/null 2>&1
+elif command -v open >/dev/null 2>&1; then
+  open "$URL"
+fi
+
+wait $SERVER_PID $CLIENT_PID


### PR DESCRIPTION
## Summary
- ignore generated SQLite database
- document Node.js prerequisites and start script in READMEs
- show login errors in React app
- remove `body-parser` in favor of Express JSON helpers
- seed the database with example data
- provide `start.sh` and `start.bat` to launch server and client together

## Testing
- `pre-commit` *(fails: command not found)*