### PR TITLE
Add hashed admin credentials and editing features

### DIFF
--- a/swift_form_app/Package.swift
+++ b/swift_form_app/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version:5.5
+import PackageDescription
+
+let package = Package(
+    name: "SwiftUIFormApp",
+    platforms: [
+        .iOS(.v14), .macOS(.v11)
+    ],
+    products: [
+        .executable(name: "SwiftUIFormApp", targets: ["SwiftUIFormApp"])
+    ],
+    dependencies: [],
+    targets: [
+        .executableTarget(
+            name: "SwiftUIFormApp",
+            path: "Sources/SwiftUIFormApp"
+        )
+    ]
+)

--- a/swift_form_app/README.md
+++ b/swift_form_app/README.md
@@ -1,0 +1,22 @@
+# SwiftUIFormApp
+
+This is a small SwiftUI application that works on both iPad and Mac (using Catalyst). It functions like a simplified Google Form that stores submissions locally using SQLite.
+
+## Features
+
+- Cross‑platform (iOS/iPadOS and macOS Catalyst)
+- Enter "Name" and "Asset Tag" information
+- Submissions are stored in a local SQLite database
+- View previously submitted entries in a list
+- Admin login protected by local credentials
+- Edit or delete entries in the admin dashboard
+- Admin password stored as a SHA-256 hash
+
+### Default Admin Credentials
+
+- Username: `admin`
+- Password: `$uper@dmin`
+
+## Building
+
+Open `Package.swift` in Xcode 13 or later and run on iOS or macOS Catalyst. The code is organized in the `Sources/SwiftUIFormApp` directory and uses only SwiftUI and the built‑in SQLite3 library, so no external dependencies are required.

--- a/swift_form_app/Sources/SwiftUIFormApp/FormApp.swift
+++ b/swift_form_app/Sources/SwiftUIFormApp/FormApp.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+@main
+struct SwiftUIFormApp: App {
+    init() {
+        _ = DatabaseManager.shared // Initialize database
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/swift_form_app/Sources/SwiftUIFormApp/Models/AdminUser.swift
+++ b/swift_form_app/Sources/SwiftUIFormApp/Models/AdminUser.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// Represents an admin user stored in the local database.
+struct AdminUser {
+    var id: Int64
+    var username: String
+    var password: String
+}

--- a/swift_form_app/Sources/SwiftUIFormApp/Models/DatabaseManager.swift
+++ b/swift_form_app/Sources/SwiftUIFormApp/Models/DatabaseManager.swift
@@ -1,0 +1,149 @@
+import Foundation
+import SQLite3
+import CryptoKit
+
+/// Handles all SQLite database operations.
+final class DatabaseManager {
+    static let shared = DatabaseManager()
+    private var db: OpaquePointer?
+
+    private init() {
+        openDatabase()
+        createTables()
+        insertDefaultAdmin()
+    }
+
+    private func openDatabase() {
+        let urls = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
+        let dbURL = urls[0].appendingPathComponent("form.sqlite")
+        let result = sqlite3_open(dbURL.path, &db)
+        check(result, message: "Unable to open database")
+    }
+
+    /// Log SQLite errors if the return code indicates a failure.
+    private func check(_ code: Int32, message: String) {
+        guard code != SQLITE_OK && code != SQLITE_DONE && code != SQLITE_ROW else { return }
+        if let err = sqlite3_errmsg(db) {
+            print("\(message): \(String(cString: err))")
+        } else {
+            print("\(message): Unknown SQLite error")
+        }
+    }
+
+    private func createTables() {
+        let createEntries = "CREATE TABLE IF NOT EXISTS entries(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, asset_tag TEXT NOT NULL, timestamp REAL NOT NULL);"
+        let createAdmins = "CREATE TABLE IF NOT EXISTS admins(id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE, password TEXT);"
+        check(sqlite3_exec(db, createEntries, nil, nil, nil), message: "Create entries table failed")
+        check(sqlite3_exec(db, createAdmins, nil, nil, nil), message: "Create admins table failed")
+    }
+
+    /// Compute a SHA-256 hash from the given string.
+    private func sha256(_ string: String) -> String {
+        let digest = SHA256.hash(data: Data(string.utf8))
+        return digest.compactMap { String(format: "%02x", $0) }.joined()
+    }
+
+    func insertEntry(name: String, assetTag: String) {
+        var stmt: OpaquePointer?
+        let sql = "INSERT INTO entries(name, asset_tag, timestamp) VALUES(?,?,?);"
+        let prep = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)
+        if prep == SQLITE_OK {
+            sqlite3_bind_text(stmt, 1, (name as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(stmt, 2, (assetTag as NSString).utf8String, -1, nil)
+            sqlite3_bind_double(stmt, 3, Date().timeIntervalSince1970)
+            check(sqlite3_step(stmt), message: "Insert entry failed")
+        } else {
+            check(prep, message: "Insert entry prepare failed")
+        }
+        sqlite3_finalize(stmt)
+    }
+
+    func fetchEntries() -> [Entry] {
+        var stmt: OpaquePointer?
+        let sql = "SELECT id, name, asset_tag, timestamp FROM entries ORDER BY timestamp DESC;"
+        var result: [Entry] = []
+        let prep = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)
+        if prep == SQLITE_OK {
+            while sqlite3_step(stmt) == SQLITE_ROW {
+                let id = sqlite3_column_int64(stmt, 0)
+                let name = String(cString: sqlite3_column_text(stmt, 1))
+                let assetTag = String(cString: sqlite3_column_text(stmt, 2))
+                let time = sqlite3_column_double(stmt, 3)
+                result.append(Entry(id: id, name: name, assetTag: assetTag, timestamp: Date(timeIntervalSince1970: time)))
+            }
+        } else {
+            check(prep, message: "Fetch entries prepare failed")
+        }
+        sqlite3_finalize(stmt)
+        return result
+    }
+
+    func deleteEntry(id: Int64) {
+        var stmt: OpaquePointer?
+        let sql = "DELETE FROM entries WHERE id=?;"
+        let prepDel = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)
+        if prepDel == SQLITE_OK {
+            sqlite3_bind_int64(stmt, 1, id)
+            check(sqlite3_step(stmt), message: "Delete entry failed")
+        } else {
+            check(prepDel, message: "Delete entry prepare failed")
+        }
+        sqlite3_finalize(stmt)
+    }
+
+    func updateEntry(_ entry: Entry) {
+        var stmt: OpaquePointer?
+        let sql = "UPDATE entries SET name=?, asset_tag=? WHERE id=?;"
+        let prepUpd = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)
+        if prepUpd == SQLITE_OK {
+            sqlite3_bind_text(stmt, 1, (entry.name as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(stmt, 2, (entry.assetTag as NSString).utf8String, -1, nil)
+            sqlite3_bind_int64(stmt, 3, entry.id)
+            check(sqlite3_step(stmt), message: "Update entry failed")
+        } else {
+            check(prepUpd, message: "Update entry prepare failed")
+        }
+        sqlite3_finalize(stmt)
+    }
+
+    func authenticateAdmin(username: String, password: String) -> Bool {
+        var stmt: OpaquePointer?
+        let sql = "SELECT COUNT(*) FROM admins WHERE username=? AND password=?;"
+        var success = false
+        let prep = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)
+        if prep == SQLITE_OK {
+            sqlite3_bind_text(stmt, 1, (username as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(stmt, 2, (sha256(password) as NSString).utf8String, -1, nil)
+            if sqlite3_step(stmt) == SQLITE_ROW {
+                success = sqlite3_column_int(stmt, 0) > 0
+            }
+        } else {
+            check(prep, message: "Authenticate admin prepare failed")
+        }
+        sqlite3_finalize(stmt)
+        return success
+    }
+
+    private func insertDefaultAdmin() {
+        var stmt: OpaquePointer?
+        let check = "SELECT COUNT(*) FROM admins WHERE username='admin';"
+        var exists = false
+        if sqlite3_prepare_v2(db, check, -1, &stmt, nil) == SQLITE_OK {
+            if sqlite3_step(stmt) == SQLITE_ROW {
+                exists = sqlite3_column_int(stmt, 0) > 0
+            }
+        }
+        sqlite3_finalize(stmt)
+        if !exists {
+            let insert = "INSERT INTO admins(username, password) VALUES(?, ?);"
+            var insertStmt: OpaquePointer?
+            if sqlite3_prepare_v2(db, insert, -1, &insertStmt, nil) == SQLITE_OK {
+                sqlite3_bind_text(insertStmt, 1, ("admin" as NSString).utf8String, -1, nil)
+                let hashed = sha256("$uper@dmin")
+                sqlite3_bind_text(insertStmt, 2, (hashed as NSString).utf8String, -1, nil)
+                check(sqlite3_step(insertStmt), message: "Insert default admin failed")
+            }
+            sqlite3_finalize(insertStmt)
+        }
+    }
+}

--- a/swift_form_app/Sources/SwiftUIFormApp/Models/Entry.swift
+++ b/swift_form_app/Sources/SwiftUIFormApp/Models/Entry.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Simple model representing a form submission.
+struct Entry: Identifiable {
+    var id: Int64
+    var name: String
+    var assetTag: String
+    var timestamp: Date
+}

--- a/swift_form_app/Sources/SwiftUIFormApp/ViewModels/AdminViewModel.swift
+++ b/swift_form_app/Sources/SwiftUIFormApp/ViewModels/AdminViewModel.swift
@@ -1,0 +1,13 @@
+import Foundation
+import Combine
+
+/// View model managing admin authentication state.
+final class AdminViewModel: ObservableObject {
+    @Published var loggedIn = false
+
+    func login(username: String, password: String) -> Bool {
+        let success = DatabaseManager.shared.authenticateAdmin(username: username, password: password)
+        loggedIn = success
+        return success
+    }
+}

--- a/swift_form_app/Sources/SwiftUIFormApp/ViewModels/EntryViewModel.swift
+++ b/swift_form_app/Sources/SwiftUIFormApp/ViewModels/EntryViewModel.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Combine
+
+/// View model handling CRUD operations for form entries.
+final class EntryViewModel: ObservableObject {
+    @Published private(set) var entries: [Entry] = []
+
+    init() {
+        loadEntries()
+    }
+
+    func loadEntries() {
+        entries = DatabaseManager.shared.fetchEntries()
+    }
+
+    func addEntry(name: String, assetTag: String) {
+        guard !name.isEmpty, !assetTag.isEmpty else { return }
+        DatabaseManager.shared.insertEntry(name: name, assetTag: assetTag)
+        loadEntries()
+    }
+
+    func deleteEntries(at offsets: IndexSet) {
+        for index in offsets {
+            let entry = entries[index]
+            DatabaseManager.shared.deleteEntry(id: entry.id)
+        }
+        loadEntries()
+    }
+
+    func updateEntry(_ entry: Entry) {
+        DatabaseManager.shared.updateEntry(entry)
+        loadEntries()
+    }
+}

--- a/swift_form_app/Sources/SwiftUIFormApp/Views/AdminDashboardView.swift
+++ b/swift_form_app/Sources/SwiftUIFormApp/Views/AdminDashboardView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+/// Dashboard showing all submissions with options to edit or delete.
+struct AdminDashboardView: View {
+    @Environment(\.presentationMode) private var presentation
+    @ObservedObject var viewModel: EntryViewModel
+    @ObservedObject var adminViewModel: AdminViewModel
+    @State private var editingEntry: Entry?
+
+    var body: some View {
+        NavigationView {
+            List {
+                ForEach(viewModel.entries) { entry in
+                    Button(action: { editingEntry = entry }) {
+                        VStack(alignment: .leading) {
+                            Text(entry.name).font(.headline)
+                            Text(entry.assetTag).font(.subheadline)
+                        }
+                    }
+                }
+                .onDelete(perform: viewModel.deleteEntries)
+            }
+            .navigationTitle("Admin Dashboard")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Close") {
+                        adminViewModel.loggedIn = false
+                        presentation.wrappedValue.dismiss()
+                    }
+                }
+            }
+        }
+        .sheet(item: $editingEntry) { entry in
+            EditEntryView(entry: entry, viewModel: viewModel)
+        }
+    }
+}

--- a/swift_form_app/Sources/SwiftUIFormApp/Views/AdminLoginView.swift
+++ b/swift_form_app/Sources/SwiftUIFormApp/Views/AdminLoginView.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+/// Login screen for admin users.
+struct AdminLoginView: View {
+    @Environment(\.presentationMode) private var presentation
+    @State private var username: String = ""
+    @State private var password: String = ""
+    @State private var showError = false
+
+    var viewModel: EntryViewModel
+    @StateObject private var admin = AdminViewModel()
+
+    var body: some View {
+        NavigationView {
+            Form {
+                TextField("Username", text: $username)
+                SecureField("Password", text: $password)
+                Button("Login") {
+                    if !admin.login(username: username, password: password) {
+                        showError = true
+                    }
+                }
+            }
+            .alert(isPresented: $showError) {
+                Alert(title: Text("Invalid credentials"))
+            }
+            .navigationTitle("Admin Login")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { presentation.wrappedValue.dismiss() }
+                }
+            }
+        }
+        .sheet(isPresented: $admin.loggedIn) {
+            AdminDashboardView(viewModel: viewModel, adminViewModel: admin)
+        }
+    }
+}

--- a/swift_form_app/Sources/SwiftUIFormApp/Views/ContentView.swift
+++ b/swift_form_app/Sources/SwiftUIFormApp/Views/ContentView.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+/// Landing page with submission form and list of existing entries.
+struct ContentView: View {
+    @State private var name: String = ""
+    @State private var assetTag: String = ""
+    @State private var showAdminLogin = false
+    @ObservedObject var viewModel = EntryViewModel()
+
+    var body: some View {
+        NavigationView {
+            VStack {
+                Form {
+                    Section(header: Text("New Submission")) {
+                        TextField("Name", text: $name)
+                        TextField("Asset Tag", text: $assetTag)
+                        Button("Submit") {
+                            guard !name.isEmpty, !assetTag.isEmpty else { return }
+                            viewModel.addEntry(name: name, assetTag: assetTag)
+                            name = ""
+                            assetTag = ""
+                        }
+                    }
+                }
+                .frame(maxWidth: 600)
+
+                List {
+                    ForEach(viewModel.entries) { entry in
+                        SubmissionRow(entry: entry)
+                    }
+                }
+                .frame(maxWidth: .infinity)
+
+                Button("Login as Admin") {
+                    showAdminLogin.toggle()
+                }
+                .padding()
+            }
+            .navigationTitle("Asset Form")
+            .sheet(isPresented: $showAdminLogin) {
+                AdminLoginView(viewModel: viewModel)
+            }
+        }
+    }
+}
+
+struct SubmissionRow: View {
+    let entry: Entry
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text(entry.name).font(.headline)
+            Text(entry.assetTag).font(.subheadline)
+        }
+    }
+}

--- a/swift_form_app/Sources/SwiftUIFormApp/Views/EditEntryView.swift
+++ b/swift_form_app/Sources/SwiftUIFormApp/Views/EditEntryView.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+/// View for editing an existing entry.
+struct EditEntryView: View {
+    @Environment(\.presentationMode) private var presentation
+    @State private var name: String
+    @State private var assetTag: String
+    var entry: Entry
+    var viewModel: EntryViewModel
+
+    init(entry: Entry, viewModel: EntryViewModel) {
+        self.entry = entry
+        self.viewModel = viewModel
+        _name = State(initialValue: entry.name)
+        _assetTag = State(initialValue: entry.assetTag)
+    }
+
+    var body: some View {
+        NavigationView {
+            Form {
+                TextField("Name", text: $name)
+                TextField("Asset Tag", text: $assetTag)
+            }
+            .navigationTitle("Edit Entry")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { presentation.wrappedValue.dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        var updated = entry
+                        updated.name = name
+                        updated.assetTag = assetTag
+                        viewModel.updateEntry(updated)
+                        presentation.wrappedValue.dismiss()
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- hash admin credentials before storing them
- add SQLite error handling and editing support
- show cancel/close buttons with cross-platform toolbars
- create `EditEntryView` for editing submissions

## Testing
- `swift --version`
- `swift build -c debug` *(fails: no such module 'SwiftUI')*